### PR TITLE
fix error: at least one resource must be specified to use a selector

### DIFF
--- a/pkg/cmd/evict.go
+++ b/pkg/cmd/evict.go
@@ -123,7 +123,7 @@ func (o *EvictOptions) Complete(cmd *cobra.Command, args []string) error {
 		b.ResourceNames("pods", o.ResourceArg)
 	}
 	if o.Selector != "" {
-		b.ResourceNames("pods").LabelSelectorParam(o.Selector)
+		b.ResourceTypes("pods").LabelSelectorParam(o.Selector)
 	}
 
 	infos, err := b.Do().Infos()


### PR DESCRIPTION
fix error: `at least one resource must be specified to use a selector` since label filter should be applied to resource types instead of names